### PR TITLE
Don't crash when `code` is not a string.

### DIFF
--- a/components/src/error/summary.tsx
+++ b/components/src/error/summary.tsx
@@ -77,7 +77,7 @@ export function ErrorSummary({ token, data }: ErrorSummaryProps) {
               onClick={() =>
                 openFile?.({
                   filePath: stack?.[0]?.file,
-                  line: stack?.[0]?.line_number,
+                  line: (stack?.[0]?.line_number || 1) - 1, // vscode lines are 0-indexed
                   column: stack?.[0]?.column_number,
                 })
               }

--- a/components/src/error/summary.tsx
+++ b/components/src/error/summary.tsx
@@ -20,6 +20,14 @@ type ErrorSummaryProps = {
   data?: ErrorDetails;
 };
 
+const formatCode = (code: any) => {
+  if(typeof code == "string"){ return code; }
+  if(Array.isArray(code)) { return code.join('\n'); }
+  if(typeof code == "object") { return Object.values(code).join('\n'); }
+  // avoid crashing if we get an unexpected type
+  return JSON.stringify(code);
+};
+
 export function ErrorSummary({ token, data }: ErrorSummaryProps) {
   const { openFile } = useVSCode();
 
@@ -82,7 +90,7 @@ export function ErrorSummary({ token, data }: ErrorSummaryProps) {
           {stack?.[0]?.code && (
             <>
               <Spacer height="4px" />
-              <pre>{stack?.[0]?.code}</pre>
+              <pre>{formatCode(stack[0].code)}</pre>
             </>
           )}
           <Spacer height="16px" />

--- a/components/src/list/stacktrace.tsx
+++ b/components/src/list/stacktrace.tsx
@@ -19,7 +19,7 @@ export function StacktraceList({ items }: StacktraceListProps) {
               e.stopPropagation();
               openFile?.({
                 filePath: item.file,
-                line: item.line_number,
+                line: (item.line_number || 1) - 1, // vscode lines are 0-indexed
                 column: item.column_number,
               });
             }}


### PR DESCRIPTION
React caused the crash as `code` was an object and it got all confused about what to do.

Extract the code block from the object and print as string, as it would if `code` were a string.